### PR TITLE
Fix issue on string replacement

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ module.exports = function(params) {
 							} else {
 								replaceWith = filesStr;
 							}
-							newText = newText.replace(match, replaceWith);
+							newText = newText.split(match).join(replaceWith);
 						}
 					}
 				} else if (matches[1].match(/include|require/)) {
@@ -94,12 +94,12 @@ module.exports = function(params) {
 						directive	= matches[2].replace(/['"]/g, '').split(/\s+/),
 						relPath		= file.base,
 						fullPath	= relPath + directive[1];
-						extension	= directive[1].split(".").pop()
+						extension	= directive[1].split(".").pop();
 
 					if (fs.existsSync(fullPath)) {
 						if (matchExtension(extension, params)) {
 							var includeContent = String(fs.readFileSync(fullPath));
-							newText = newText.replace(match, includeContent + gutil.linefeed);
+							newText = newText.split(match).join(includeContent + gutil.linefeed);
 						}
 					} else {
 						throw new gutil.PluginError('gulp-include', 'File not found: ' + fullPath);

--- a/test/expected/app_all_extensions.js
+++ b/test/expected/app_all_extensions.js
@@ -1,3 +1,6 @@
+nid = old.replace( rescape, "\\$&"  );
+
+
 header text content
 
 
@@ -33,4 +36,5 @@ nested txt
 nested txt2
 
 e content
+
 

--- a/test/expected/app_multiple_extensions.js
+++ b/test/expected/app_multiple_extensions.js
@@ -1,3 +1,6 @@
+nid = old.replace( rescape, "\\$&"  );
+
+
 header text content
 
 
@@ -34,4 +37,5 @@ nested txt
 nested txt2
 
 e content
+
 

--- a/test/expected/app_only_txt.js
+++ b/test/expected/app_only_txt.js
@@ -1,3 +1,4 @@
+//= include sample.js
 header text content
 
 
@@ -21,4 +22,5 @@ var object = {};
 nested txt
 
 nested txt2
+
 

--- a/test/fixatures/app.js
+++ b/test/fixatures/app.js
@@ -1,3 +1,4 @@
+//= include sample.js
 //= include header.txt
 
 // =include lib/a.js

--- a/test/fixatures/sample.js
+++ b/test/fixatures/sample.js
@@ -1,0 +1,1 @@
+nid = old.replace( rescape, "\\$&"  );


### PR DESCRIPTION
Target files may have special strings used by
replace() function [1].

So this commits changes "replace()" with an
alternative way to replace strings.

[1] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace
