### PR TITLE
support for prepend and append

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ gulp.task("scripts", function() {
 gulp.task("default", "scripts");
 ```
 
+## Prepend and Append
+We support prepend and append to the file with the codekit syntax:
+
+```javascript
+// @codekit-prepend relative/path/to/file.js
+// @codekit-append relative/path/to/file.js
+// @codekit-prepend "relative/path/to/file.js ", "relative/path/to/file.js "
+```
+
 ## Options
 * `extensions` (optional)
 	* Takes a `String` or an `Array` of extensions, eg: `"js"` or `["js", "coffee"]`

--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ module.exports = function (params) {
     var params = params || {};
     requiredFiles = {};
     extensions = [];
+    prependCache = '';
+    appendCache = '';
 
     if (params.extensions) {
         extensions = typeof params.extensions === 'string' ? [params.extensions] : params.extensions;
@@ -130,6 +132,10 @@ function globMatch(match, filePath) {
     }
 
     if (directiveType === 'require' || directiveType === 'include' || directiveType.indexOf('codekit') !== -1) {
+        if (relativeFilePath.charAt(0).match(/['"]/g)) {
+            // optional [] on multiple files
+            relativeFilePath = '[' + relativeFilePath + ']';
+        }
         if (relativeFilePath.charAt(0) === '[') {
             relativeFilePath = eval(relativeFilePath);
             for (var i = 0; i < relativeFilePath.length; i++) {

--- a/index.js
+++ b/index.js
@@ -9,9 +9,7 @@ var PREPEND_REGEX = /^[\/\s#]*\s*?((?:@codekit-prepend))\s+(.*$)/mg;
 var APPEND_REGEX = /^[\/\s#]*\s*?((?:@codekit-append))\s+(.*$)/mg;
 
 var requiredFiles = {},
-    extensions = [],
-    prependCache = '',
-    appendCache = '';
+    extensions = [];
 
 module.exports = function (params) {
     var params = params || {};

--- a/index.js
+++ b/index.js
@@ -4,11 +4,14 @@ var fs = require('fs'),
     gutil = require('gulp-util'),
     glob = require('glob');
 
-
 var DIRECTIVE_REGEX = /^[\/\s#]*?=\s*?((?:require|include)(?:_tree|_directory)?)\s+(.*$)/mg;
+var PREPEND_REGEX = /^[\/\s#]*\s*?((?:@codekit-prepend))\s+(.*$)/mg;
+var APPEND_REGEX = /^[\/\s#]*\s*?((?:@codekit-append))\s+(.*$)/mg;
 
 var requiredFiles = {},
-    extensions = [];
+    extensions = [],
+    prependCache = '',
+    appendCache = '';
 
 module.exports = function (params) {
     var params = params || {};
@@ -29,7 +32,11 @@ module.exports = function (params) {
         }
 
         if (file.isBuffer()) {
-            var newText = expand(String(file.contents), file.path);
+            var newText = expand(String(file.contents), file.path, DIRECTIVE_REGEX);
+            newText = expand(newText, file.path, PREPEND_REGEX);
+            newText = prependCache + newText;
+            newText = expand(newText, file.path, APPEND_REGEX);
+            newText = newText + appendCache;
             file.contents = new Buffer(newText);
         }
 
@@ -39,15 +46,15 @@ module.exports = function (params) {
     return es.map(include)
 };
 
-function expand(fileContents, filePath) {
+function expand(fileContents, filePath, regex) {
     var regexMatch,
         matches = [],
         returnText = fileContents,
         i, j;
 
-    DIRECTIVE_REGEX.lastIndex = 0;
+    regex.lastIndex = 0;
 
-    while (regexMatch = DIRECTIVE_REGEX.exec(fileContents)) {
+    while (regexMatch = regex.exec(fileContents)) {
         matches.push(regexMatch);
     }
 
@@ -70,7 +77,7 @@ function expand(fileContents, filePath) {
 
         for (j = 0; j < files.length; j++) {
             fileName = files[j];
-            newMatchText = expand(String(fs.readFileSync(fileName)), fileName);
+            newMatchText = expand(String(fs.readFileSync(fileName)), fileName, regex);
 
             //Try to retain the same indent level from the original include line
             whitespace = original.match(/^\s+/);
@@ -85,15 +92,21 @@ function expand(fileContents, filePath) {
             }
 
             thisMatchText += newMatchText + "\n";
-            
-            if (directiveType.indexOf('require') !== -1 || directiveType.indexOf('include') !== -1) {
+
+            if (directiveType.indexOf('require') !== -1 || directiveType.indexOf('include') !== -1 || directiveType.indexOf('codekit') !== -1) {
                 requiredFiles[fileName] = true;
             }
         }
 
         thisMatchText = thisMatchText || original;
 
-        returnText = replaceStringByIndices(returnText, start, end, thisMatchText);
+        if(directiveType === '@codekit-prepend'){
+            returnText = prependString(returnText, start, end, thisMatchText);
+        }else if(directiveType === '@codekit-append'){
+            returnText = appendString(returnText, start, end, thisMatchText);
+        }else{
+            returnText = replaceStringByIndices(returnText, start, end, thisMatchText);
+        }
     }
 
     return returnText ? returnText : fileContents;
@@ -116,7 +129,7 @@ function globMatch(match, filePath) {
         directiveType = directiveType.replace('_directory', '');
     }
 
-    if (directiveType === 'require' || directiveType === 'include') {
+    if (directiveType === 'require' || directiveType === 'include' || directiveType.indexOf('codekit') !== -1) {
         if (relativeFilePath.charAt(0) === '[') {
             relativeFilePath = eval(relativeFilePath);
             for (var i = 0; i < relativeFilePath.length; i++) {
@@ -177,6 +190,18 @@ function _internalGlob(thisGlob, filePath) {
 function replaceStringByIndices(string, start, end, replacement) {
     return string.substring(0, start) + replacement + string.substring(end);
 }
+function prependString(string, start, end, prepend) {
+    // cache prepend
+    prependCache = prepend + prependCache;
+    // remove directive
+    return string.substring(0, start) + string.substring(end);
+}
+function appendString(string, start, end, append) {
+    // cache append
+    appendCache = append + appendCache;
+    // remove directive
+    return string.substring(0, start) + string.substring(end);
+}
 
 function addLeadingWhitespace(whitespace, string) {
     return string.split("\n").map(function(line) {
@@ -189,7 +214,7 @@ function union(arr1, arr2) {
     if (arr1.length == 0) {
         return arr2;
     }
-    
+
     var index;
     for (var i = 0; i < arr2.length; i++) {
         if ((index = arr1.indexOf(arr2[i])) !== -1) {


### PR DESCRIPTION
with

```
// @codekit-prepend path/to/file.js
// @codekit-append path/to/file.js
```

As I explained it's the syntax this 'precompiler' sofwares use. https://github.com/wiledal/gulp-include/issues/30

The lines added are very simple, I just:
- added one regex for prepend and one regex for append (you should be able to add your own if you want)
- executed `expand()` with the new argument `regex`
- added directive checks
- with the functions `prependString()` and `appendString()` I cached the results, that I add to `newText` during buffer.

Also I added optional `[]` on multiple files for this syntax

```
// @codekit-prepend "path/to/file.js", "path/to/file.js"
```
