### PR TITLE
Added function to create an array of the files that will be involved in an include

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,27 @@ gulp.task("default", "scripts");
 	* Takes a `String` or an `Array` of extensions, eg: `"js"` or `["js", "coffee"]`
 	* If set, all inclusions that does not match the extension(s) will be ignored
 
+## File List
+An array of files included (useful for watching) can be produced by using the
+`files` function. For example:
+```javascript
+var include = require('gulp-include');
+
+gulp.task("scripts", function() {
+	gulp.src('src/js/app.coffee')
+		.pipe( include() )
+		.pipe( coffee() )
+		.pipe( gulp.dest("dist/js") )
+});
+
+gulp.task("scripts", function() {
+	gulp.watch(include.files('src/js/app.coffee'), ["scripts"])
+});
+
+gulp.task("default", ["scripts", "watch"]);
+});
+```
+
 ## Release log
 #### 1.1.1
 * Merged community fix by [trolev](https://github.com/trolev)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ gulp.task("default", "scripts");
 An array of files included (useful for watching) can be produced by using the
 `files` function. For example:
 ```javascript
-var include = require('gulp-include');
+var gulp		= require('gulp'),
+	include		= require('gulp-include'),
+	coffee		= require('gulp-coffee');
 
 gulp.task("scripts", function() {
 	gulp.src('src/js/app.coffee')

--- a/index.js
+++ b/index.js
@@ -39,12 +39,23 @@ module.exports = function (params) {
     return es.map(include)
 };
 
-module.exports.files = function(files, params) {
+module.exports.files = function(glob, params) {
     var params = params || {},
         f, files, fullFiles;
     extensions = [];
-        
-    files = _internalGlob(files, ''),
+ 
+ 		if (glob instanceof Array) {
+			var g;
+			files = [];
+			for (g in glob) {
+				files = union(files, _internalGlob(glob[g], ''));
+			}
+		} else if (typeof glob == "string") {
+    	files = _internalGlob(glob, '');
+		} else {
+			throw new TypeError('Glob must either be a string or an array of strings');
+		}
+
     fullFiles = [].concat(files);
 
     if (params.extensions) {

--- a/test/main.js
+++ b/test/main.js
@@ -73,6 +73,153 @@ describe("gulp-include", function () {
         })
     })
 
+    describe("File listing", function () {
+
+        it("should list the files from special comments", function () {
+            files = include.files("test/fixtures/app.js");
+
+            should.exist(files);
+
+            files.should.eql([
+                "test/fixtures/app.js",
+                "test/fixtures/lib/nested/deeply_nested/d.js",
+                "test/fixtures/lib/nested/deeply_nested/deeper/f.js",
+                "test/fixtures/lib/nested/deeply_nested/deeper/nested_txt.txt",
+                "test/fixtures/lib/nested/deeply_nested/deeper/nested_txt2.txt",
+                "test/fixtures/lib/nested/deeply_nested/e.js",
+                "test/fixtures/lib/nested/c.js",
+                "test/fixtures/lib/b.js",
+                "test/fixtures/lib/a.js",
+                "test/fixtures/header.txt",
+                "test/fixtures/sample.js"
+            ]);
+        });
+
+        it("should only list the files with the provided SINGLE extension", function () {
+            files = include.files("test/fixtures/app.js", {
+                extensions: "txt"
+            });
+
+            should.exist(files);
+
+            files.should.eql([
+                "test/fixtures/app.js",
+                "test/fixtures/lib/nested/deeply_nested/deeper/nested_txt.txt",
+                "test/fixtures/lib/nested/deeply_nested/deeper/nested_txt2.txt",
+                "test/fixtures/header.txt"
+            ]);
+        });
+
+        it("should only include the files with the provided MULTIPLE extensions", function () {
+            files = include.files("test/fixtures/app.js", {
+                extensions: ["txt", "js"]
+            });
+
+            should.exist(files);
+
+            files.should.eql([
+                "test/fixtures/app.js",
+                "test/fixtures/lib/nested/deeply_nested/d.js",
+                "test/fixtures/lib/nested/deeply_nested/deeper/f.js",
+                "test/fixtures/lib/nested/deeply_nested/deeper/nested_txt.txt",
+                "test/fixtures/lib/nested/deeply_nested/deeper/nested_txt2.txt",
+                "test/fixtures/lib/nested/deeply_nested/e.js",
+                "test/fixtures/lib/nested/c.js",
+                "test/fixtures/lib/b.js",
+                "test/fixtures/lib/a.js",
+                "test/fixtures/header.txt",
+                "test/fixtures/sample.js"
+            ]);
+        });
+
+        it("should list files with a relative path", function () {
+            files = include.files("test/fixtures/relative/app.js", {
+                extensions: ['js']
+            });
+
+            should.exist(files);
+
+            files.should.eql([
+                "test/fixtures/relative/app.js",
+                "test/fixtures/sample.js"
+            ]);
+        })
+
+        it("Should work on recursive includes", function () {
+            files = include.files("test/fixtures/app_recursive.js", {
+                extensions: ['js']
+            });
+
+            should.exist(files);
+
+            files.should.eql([
+                "test/fixtures/app_recursive.js",
+                "test/fixtures/recursive/a.js",
+                "test/fixtures/recursive/b.js",
+                "test/fixtures/recursive/nested/c.js",
+                "test/fixtures/recursive/nested/deeply_nested/d.js",
+                "test/fixtures/recursive/nested/deeply_nested2/e.js"
+            ]);
+        })
+
+        it("Should work on glob includes", function () {
+            files = include.files("test/fixtures/globs/app.js", {
+                extensions: ['js']
+            });
+
+            should.exist(files);
+
+            files.should.eql([
+                "test/fixtures/globs/app.js",
+                "test/fixtures/globs/nested/b.js",
+                "test/fixtures/globs/nested/c.js",
+                "test/fixtures/globs/nested/nested_deeper/d.js",
+                "test/fixtures/globs/nested/a.js"
+            ]);
+        })
+
+        it("Should match leading whitespace", function () {
+            files = include.files("test/fixtures/whitespace/a.js", {
+                extensions: 'js'
+            });
+
+            should.exist(files);
+
+            files.should.eql([
+                "test/fixtures/whitespace/a.js",
+                "test/fixtures/whitespace/d.js",
+                "test/fixtures/whitespace/c.js",
+                "test/fixtures/whitespace/b.js"
+            ]);
+        })
+        
+        it("Should retain origin file's leading whitespace", function () {
+            files = include.files("test/fixtures/whitespace/a_origin.js", {
+                extensions: 'js'
+            });
+
+            should.exist(files);
+
+            files.should.eql([
+                "test/fixtures/whitespace/a_origin.js",
+                "test/fixtures/whitespace/d.js",
+                "test/fixtures/whitespace/b.js"
+            ]);
+        })
+
+        it("Should work with css files", function () {
+            files = include.files("test/fixtures/styles/a.css");
+
+            should.exist(files);
+
+            files.should.eql([
+                "test/fixtures/styles/a.css",
+                "test/fixtures/styles/b.css"
+            ]);
+        })
+
+    })
+
     describe("File replacing", function () {
 
         it("should replace special comments with file contents", function (done) {


### PR DESCRIPTION
Hello,

Very helpful basic way of including files in other files - exactly what I needed. To enable me to be lazy and not create a list of all the source files for a gulp watch command, I have added and files function to the include function to generate an array containing the files that will be involved in an include. I have added tests and a blurb to the README as well.

Hope you like it/find it useful.
