### PR TITLE
Add support for HTML comments (feature)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Example directives:
 ```coffee
 #=include relative/path/to/file.coffee
 ```
+```html
+<!--=include relative/path/to/file.html -->
+```
+
 The contents of the referenced file will replace the file.
   
 ### `require` vs. `include`

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = function (params) {
 };
 
 function processInclude(content, filePath) {
-  var matches = content.match(/^(\s+)?(\/\/|\/\*|\#)(\s+)?=(\s+)?(include|require)(.+$)/mg);
+  var matches = content.match(/^(\s+)?(\/\/|\/\*|\#|\<\!\-\-)(\s+)?=(\s+)?(include|require)(.+$)/mg);
   var relativeBasePath = path.dirname(filePath);
   
   if (!matches) return content;


### PR DESCRIPTION
To make this plugin work with HTML files, add the ability to recognize HTML comments as includes.