### PR TITLE
Prefixing unicode byte order marks are stripped from included files

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ var fs = require('fs'),
     es = require('event-stream'),
     gutil = require('gulp-util'),
     glob = require('glob'),
-    applySourceMap = require('vinyl-sourcemaps-apply');
+    applySourceMap = require('vinyl-sourcemaps-apply'),
+    stripBom = require('strip-bom');
 
 var SourceMapGenerator = require('source-map').SourceMapGenerator;
 var SourceMapConsumer = require('source-map').SourceMapConsumer;
@@ -134,7 +135,8 @@ function processInclude(content, filePath, sourceMap) {
       if (!inExtensions(globbedFilePath)) continue; 
       
       // Get file contents and apply recursive include on result
-      var fileContents = fs.readFileSync(globbedFilePath);
+      // Unicode byte order marks are stripped from the start of included files
+      var fileContents = stripBom(fs.readFileSync(globbedFilePath));
       
       var result = processInclude(fileContents.toString(), globbedFilePath, sourceMap);
       var resultContent = result.content;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "glob": "^5.0.12",
     "gulp-util": "~2.2.10",
     "source-map": "^0.5.1",
+    "strip-bom": "^2.0.0",
     "vinyl-sourcemaps-apply": "^0.2.0"
   }
 }

--- a/test/expected/html/basic-include-output-with-unicode-BOM.html
+++ b/test/expected/html/basic-include-output-with-unicode-BOM.html
@@ -1,0 +1,10 @@
+﻿<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Test</title>
+  </head>
+  <body>
+    <div>This is a test</div>
+  </body>
+</html>

--- a/test/fixtures/html/basic-include-with-unicode-BOM.html
+++ b/test/fixtures/html/basic-include-with-unicode-BOM.html
@@ -1,0 +1,10 @@
+﻿<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Test</title>
+  </head>
+  <body>
+    <!--=include test-with-unicode-BOM.html -->
+  </body>
+</html>

--- a/test/fixtures/html/test-with-unicode-BOM.html
+++ b/test/fixtures/html/test-with-unicode-BOM.html
@@ -1,0 +1,1 @@
+﻿<div>This is a test</div>

--- a/test/main.js
+++ b/test/main.js
@@ -152,4 +152,23 @@ describe("gulp-include", function () {
       }))
       .pipe(assert.end(done));
   });
+
+  it('should strip unicode byte order marks from included files', function (done) {
+    var file = new gutil.File({
+      base: "test/fixtures/",
+      path: "test/fixtures/html/basic-include-with-unicode-BOM.html",
+      contents: fs.readFileSync("test/fixtures/html/basic-include-with-unicode-BOM.html")
+    });
+
+    testInclude = include();
+    testInclude.on("data", function (newFile) {
+      should.exist(newFile);
+      should.exist(newFile.contents);
+
+      String(newFile.contents).should.equal(String(fs.readFileSync("test/expected/html/basic-include-output-with-unicode-BOM.html"), "utf8"))
+      done();
+    });
+
+    testInclude.write(file);
+  })
 })


### PR DESCRIPTION
Some tools (particularly those on Windows - in particular, Visual Studio defaults to this behaviour) have a habit of saving unicode byte order marks (BOMs) at the start of all UTF-8 files (despite these not being necessary). These should be trimmed before being included. See https://github.com/nodejs/node-v0.x-archive/issues/1918 for details concerning this.

An example of the bug is below (note that \ufeff is an example of a unicode BOM)

_file1.html_:
\ufeff This is some text.
<!--=include file2.html -->

_file2.html_:
\ufeff Some text here

_Results in file 1 reading_:
This is some text.
ï»¿ Some text here

This occurs because BOMs should not occur in the middle of files (only at their starts)
