### PR TITLE
start with ./ auto include file from absolute path

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,8 +150,12 @@ module.exports = function (params) {
           fileMatches = fileMatches.concat(globResults);
         }
       }else{
-        // Otherwise search relatively
-        includePath = relativeBasePath + "/" + split[1];
+        // Otherwise search relatively          
+        if( split[1].substr(0,2) == './' )
+            includePath = path.resolve('.') + "" + split[1].substr(1);
+        else
+            includePath = relativeBasePath + "/" + split[1];
+
         var globResults = glob.sync(includePath, {mark: true});
         fileMatches = globResults;
       }


### PR DESCRIPTION
if require or include inner script
when i start with "./" i wan't to auto include file from absolute path,

Example.
//= require ./resources/script/test.js

output
/home/username/domains/domain.com/public_html/resources/script/test.js

your option includePath is not support with this string "./"