### PR TITLE
Allow explicit relative paths even when includePaths set

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ gulp.task("default", ["scripts"]);
   * Takes a `String` or an `Array` of paths.  
   eg: `__dirname + "/node_modules"` or `[__dirname + "/assets/js", __dirname + "/bower_components"]`
   * If set, `gulp-include` will use these folders as base path when searching for files.
+  * If set, you can still include files relative to the current file by pre-pending includes with `./`.
 
 
 - `hardFail` (optional)
@@ -76,6 +77,7 @@ Example directives:
 //=require vendor/jquery.js
 //=require vendor/**/*.js
 //=include relative/path/to/file.js
+//=include ./relative/path/to/file-even-when-includePaths-set.js
 ```
 ```css
 /*=include relative/path/to/file.css */

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ module.exports = function (params) {
       var fileMatches = [];
       var includePath = "";
 
-      if (includePaths != false) {
+      if (includePaths != false && !isExplicitRelativePath(split[1])) {
         // If includepaths are set, search in those folders
         for (var y = 0; y < includePaths.length; y++) {
           includePath = includePaths[y] + "/" + split[1];
@@ -151,7 +151,7 @@ module.exports = function (params) {
         }
       }else{
         // Otherwise search relatively
-        includePath = relativeBasePath + "/" + split[1];
+        includePath = relativeBasePath + "/" + removeRelativePathPrefix(split[1]);
         var globResults = glob.sync(includePath, {mark: true});
         fileMatches = globResults;
       }
@@ -271,6 +271,14 @@ module.exports = function (params) {
 
   function unixStylePath(filePath) {
     return filePath.replace(/\\/g, '/');
+  }
+
+  function isExplicitRelativePath(filePath) {
+    return filePath.indexOf('./') === 0;
+  }
+
+  function removeRelativePathPrefix(filePath) {
+    return filePath.replace(/^\.\//, '');
   }
 
   function addLeadingWhitespace(whitespace, string) {

--- a/test/expected/js/include-path-relative.js
+++ b/test/expected/js/include-path-relative.js
@@ -1,0 +1,2 @@
+// include-path a.js
+// another include path file

--- a/test/expected/js/recursive-relative.js
+++ b/test/expected/js/recursive-relative.js
@@ -1,0 +1,7 @@
+// Recursive relative inclusion
+// include-path a.js
+// recursive-relative-one.js
+// recursive-relative-two.js
+// recursive-three.js
+// b.js
+// c.js

--- a/test/fixtures/js/include-path-relative.js
+++ b/test/fixtures/js/include-path-relative.js
@@ -1,0 +1,2 @@
+//= include a.js
+//= include ./include-path2/another-include-path.js

--- a/test/fixtures/js/recursive-relative.js
+++ b/test/fixtures/js/recursive-relative.js
@@ -1,0 +1,3 @@
+// Recursive relative inclusion
+//=include a.js
+//=include recursive-relative-one.js

--- a/test/fixtures/js/recursive/deeper/recursive-relative-two.js
+++ b/test/fixtures/js/recursive/deeper/recursive-relative-two.js
@@ -1,0 +1,2 @@
+// recursive-relative-two.js
+//=include ./deepest/recursive-three.js

--- a/test/fixtures/js/recursive/recursive-relative-one.js
+++ b/test/fixtures/js/recursive/recursive-relative-one.js
@@ -1,0 +1,4 @@
+// recursive-relative-one.js
+//= include ./deeper/recursive-relative-two.js
+//= include ./../deep_path/b.js
+//= include ./../deep_path/deeper_path/c.js

--- a/test/fixtures/js/recursive/recursive-relative.js
+++ b/test/fixtures/js/recursive/recursive-relative.js
@@ -1,0 +1,5 @@
+// recursive-relative.js
+//= include a.js
+//= include ./../deep_path/b.js
+//= include ./../deep_path/deeper_path/c.js
+//= include ./deeper/recursive-relative-two.js

--- a/test/main.js
+++ b/test/main.js
@@ -197,6 +197,51 @@ describe("gulp-include", function () {
     testInclude.write(file);
   })
 
+  it("should include from explicit relative path when includePaths set", function(done) {
+    var file = new gutil.File({
+      base: "test/fixtures/",
+      path: "test/fixtures/js/include-path-relative.js",
+      contents: fs.readFileSync("test/fixtures/js/include-path-relative.js")
+    });
+
+    testInclude = include({
+      includePaths: [
+        __dirname + "/fixtures/js/include-path",
+      ]
+    });
+    testInclude.on("data", function (newFile) {
+      should.exist(newFile);
+      should.exist(newFile.contents);
+
+      String(newFile.contents).should.equal(String(fs.readFileSync("test/expected/js/include-path-relative.js"), "utf8"))
+      done();
+    });
+    testInclude.write(file);
+  })
+
+  it("should include relative paths recursively when includePaths does not include recursively-included paths", function(done) {
+    var file = new gutil.File({
+      base: "test/fixtures/",
+      path: "test/fixtures/js/recursive-relative.js",
+      contents: fs.readFileSync("test/fixtures/js/recursive-relative.js")
+    });
+
+    testInclude = include({
+      includePaths: [
+        __dirname + "/fixtures/js/include-path",
+        __dirname + "/fixtures/js/recursive",
+      ]
+    });
+    testInclude.on("data", function (newFile) {
+      should.exist(newFile);
+      should.exist(newFile.contents);
+
+      String(newFile.contents).should.equal(String(fs.readFileSync("test/expected/js/recursive-relative.js"), "utf8"))
+      done();
+    });
+    testInclude.write(file);
+  })
+
   it("should throw an error if no match is found with hardFail: true", function(done) {
     var file = new gutil.File({
       base: "test/fixtures/",


### PR DESCRIPTION
Similar to #77 by @yoozze but uses an explicit mechanism to indicate when a path should be considered relative and not resolved using `includePaths`. In this PR the actual resolution is unchanged unless an include has a `./` prefix.

- Use leading dot (.) to indicate relative path
- Allow mixing of includePaths-relative includes and current-file-relative
  includes
- Allows recursive includes to work even when includePaths set
  (otherwise gulp options need to specify all recursively-included
  paths, which may not be known or difficult to specify)
- Added tests and README changes