### PR TITLE
skip files not in extensions, do not process at all

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ module.exports = function (params) {
     }
 
     if (file.isBuffer()) {
+      if (!inExtensions(file.path)) return callback(null, file);
       var result = processInclude(String(file.contents), file.path, file.sourceMap);
       file.contents = new Buffer(result.content);
 


### PR DESCRIPTION
`processInclude` function will change(corrupt) binary files like *.png,*.gif,*.jpg.
By skip files not in `extensions` before `processInclude` will solve the problem.