### PR TITLE
Add aliases option to allow named paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ gulp.task("default", ["scripts"]);
   an include directive.
   * If set to `false` gulp include will not fail, but display warnings in the console.
 
+- `aliases` (optional)
+  * Takes an `Object` of names to absolute paths  
+  eg: `{myModule: __dirname + '/my-module/*'}`
+  * If set, `gulp-include` will replace the alias with the expanded filepaths, allowing you to define global unique names (easier to read)
+
 #### Example options usage:
 ```js
 gulp.src("src/js/main.js")
@@ -63,7 +68,11 @@ gulp.src("src/js/main.js")
     includePaths: [
       __dirname + "/bower_components",
       __dirname + "/src/js"
-    ]
+    ],
+    aliases: {
+      jquery: __dirname + '/vendor/jquery.js',
+      myModule: __dirname + '/path/to/my-module/**/*.js'
+    }
   }))
   .pipe(gulp.dest("dist/js"));
 ```

--- a/test/expected/js/basic-include-aliases.js
+++ b/test/expected/js/basic-include-aliases.js
@@ -1,0 +1,3 @@
+// basic-include.js
+// b.js
+// c.js

--- a/test/fixtures/js/basic-include-aliases.js
+++ b/test/fixtures/js/basic-include-aliases.js
@@ -1,0 +1,3 @@
+// basic-include.js
+/*= include   b */
+// = include   "c"

--- a/test/main.js
+++ b/test/main.js
@@ -30,6 +30,29 @@ describe("gulp-include", function () {
       testInclude.write(file);
     });
 
+    it("should use aliases if set", function (done) {
+      var file = new gutil.File({
+        base: "test/fixtures/",
+        path: "test/fixtures/js/basic-include-aliases.js",
+        contents: fs.readFileSync("test/fixtures/js/basic-include-aliases.js")
+      });
+
+      testInclude = include({
+        aliases: {
+          b: __dirname + '/fixtures/js/deep_path/b.js',
+          c: __dirname + '/fixtures/js/deep_path/deeper_path/c.js'
+        }
+      });
+      testInclude.on("data", function (newFile) {
+        should.exist(newFile);
+        should.exist(newFile.contents);
+
+        String(newFile.contents).should.equal(String(fs.readFileSync("test/expected/js/basic-include-aliases.js"), "utf8"))
+        done();
+      });
+      testInclude.write(file);
+    });
+
     it("should keep whitespace when including", function (done) {
       var file = new gutil.File({
         base: "test/fixtures/",


### PR DESCRIPTION
Hi,

I wrote this option for my uses, maybe other users would like it too? =)

It allows users with many identical require paths across their files to declare the path once and reference with a name, e.g.
```js
//= require vendor/jquery/jquery.js
```
becomes
```js
//= require jquery
```
with options
```js
include({
  aliases: {
    jquery: __dirname + '/vendor/jquery/jquery.js'
  }
});
```

I've also updated the error message to include the filepath of the include/require, and the top-level filepath at the beginning of the recursion, to aid in debugging when multiple top-level files all include/require the same file, e.g.
```
Error: No files found matching module "jquery" /Users/me/project/js/vendor/jquery/jquery.js (source: /Users/me/project/js/deep/file_deep.js, starting from /Users/me/project/js/file.js)
```
for a project structured like so:
```
project/js
├── vendor
│   └── jquery
│   │   └── jquery.js
├── file.js
└── deep
    └── file_deep.js
```