### PR TITLE
Imrpoved the regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ module.exports = function (params) {
     }
 
     function processInclude(content, filePath, sourceMap, includedFiles) {
-        var matches = content.match(/^(\s+)?(\/\/|\/\*|\#|\<\!\-\-)(\s+)?=(\s+)?(include|require)(.+$)/mg);
+        var matches = content.match(/(\/\/|\/\*|\#|\<\!\-\-)(\s+)?=(\s+)?(include|require)([a-zA-Z\-_\.0-9\s]+)/mg);
         var relativeBasePath = path.dirname(filePath);
 
         if (!matches) return {


### PR DESCRIPTION
I saw some issues where people (including myself) suggested that you can use this awesome library for setting the value for variables like this:

`var foo = '//=include test.json';`

However, this isn't possible with the current version. I updated the regex to allow to do that. I didn't really put much effort in it so you might want to clean up some things first.